### PR TITLE
Use proper cmake build option instead of custom flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
+option( BUILD_EXAMPLE "Build example application."                  ON )
+option( BUILD_TOOL    "Build udp-discovery-tool application."       ON )
+
 set(LIB_SOURCES
 	endpoint.cpp
 	ip_port.cpp
@@ -11,29 +14,38 @@ set(LIB_HEADERS
 
 add_library(udp-discovery STATIC ${LIB_SOURCES} ${LIB_HEADERS})
 
-if(NOT "${UDP_DISCOVERY_NO_EXECUTABLES}" STREQUAL "1")
+if ( BUILD_EXAMPLE OR BUILD_TOOL )
+	if(APPLE)
+	elseif(UNIX)
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+	endif()
+endif()
+
+if ( BUILD_EXAMPLE )
 	set(DISCOVERY_EXAMPLE_SOURCES
 		discovery_example.cpp)
 	set(DISCOVERY_EXAMPLE_LIBS
 		udp-discovery)
 
+	if(APPLE)
+	elseif(UNIX)
+		set(DISCOVERY_EXAMPLE_LIBS ${DISCOVERY_EXAMPLE_LIBS} rt)
+	endif()
+
+	add_executable(udp-discovery-example ${DISCOVERY_EXAMPLE_SOURCES})
+	target_link_libraries(udp-discovery-example ${DISCOVERY_EXAMPLE_LIBS})
+endif()
+
+if ( BUILD_TOOL )
 	set(DISCOVERY_TOOL_SOURCES
 		discovery_tool.cpp)
 	set(DISCOVERY_TOOL_LIBS
 		udp-discovery)
 
-	if(WIN32)
-	set(DISCOVERY_EXAMPLE_LIBS ${DISCOVERY_EXAMPLE_LIBS}
-		Ws2_32)
-	endif(WIN32)
-
 	if(APPLE)
 	elseif(UNIX)
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+		set(DISCOVERY_TOOL_LIBS ${DISCOVERY_TOOL_LIBS} rt)
 	endif()
-
-	add_executable(udp-discovery-example ${DISCOVERY_EXAMPLE_SOURCES})
-	target_link_libraries(udp-discovery-example ${DISCOVERY_EXAMPLE_LIBS})
 
 	add_executable(udp-discovery-tool ${DISCOVERY_TOOL_SOURCES})
 	target_link_libraries(udp-discovery-tool ${DISCOVERY_TOOL_LIBS})


### PR DESCRIPTION
Use proper cmake build options
    
Require linker dependencies only if executables are built
Fix missing library linking regression introduced in my last PR

Sorry to not include it in the previous PR