### PR TITLE
Use proper cmake build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,14 @@ set(LIB_HEADERS
 
 add_library(udp-discovery STATIC ${LIB_SOURCES} ${LIB_HEADERS})
 
-if ( BUILD_EXAMPLE OR BUILD_TOOL )
+if(BUILD_EXAMPLE OR BUILD_TOOL)
 	if(APPLE)
 	elseif(UNIX)
 		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
 	endif()
 endif()
 
-if ( BUILD_EXAMPLE )
+if(BUILD_EXAMPLE)
 	set(DISCOVERY_EXAMPLE_SOURCES discovery_example.cpp)
 	set(DISCOVERY_EXAMPLE_LIBS udp-discovery)
 
@@ -38,7 +38,7 @@ if ( BUILD_EXAMPLE )
 	target_link_libraries(udp-discovery-example ${DISCOVERY_EXAMPLE_LIBS})
 endif()
 
-if ( BUILD_TOOL )
+if(BUILD_TOOL)
 	set(DISCOVERY_TOOL_SOURCES discovery_tool.cpp)
 	set(DISCOVERY_TOOL_LIBS udp-discovery)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
-option( BUILD_EXAMPLE "Build example application."                  ON )
-option( BUILD_TOOL    "Build udp-discovery-tool application."       ON )
+option(BUILD_EXAMPLE "Build example application." OFF)
+option(BUILD_TOOL "Build udp-discovery-tool application." OFF)
 
 set(LIB_SOURCES
 	endpoint.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 
+option( BUILD_EXAMPLE "Build example application."                  ON )
+option( BUILD_TOOL    "Build udp-discovery-tool application."       ON )
+
 set(LIB_SOURCES
 	endpoint.cpp
 	ip_port.cpp
@@ -11,29 +14,38 @@ set(LIB_HEADERS
 
 add_library(udp-discovery STATIC ${LIB_SOURCES} ${LIB_HEADERS})
 
-if(NOT "${UDP_DISCOVERY_NO_EXECUTABLES}" STREQUAL "1")
-	set(DISCOVERY_EXAMPLE_SOURCES
-		discovery_example.cpp)
-	set(DISCOVERY_EXAMPLE_LIBS
-		udp-discovery)
+if ( BUILD_EXAMPLE OR BUILD_TOOL )
+	if(APPLE)
+	elseif(UNIX)
+		set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+	endif()
+endif()
 
-	set(DISCOVERY_TOOL_SOURCES
-		discovery_tool.cpp)
-	set(DISCOVERY_TOOL_LIBS
-		udp-discovery)
-
-	if(WIN32)
-	set(DISCOVERY_EXAMPLE_LIBS ${DISCOVERY_EXAMPLE_LIBS}
-		Ws2_32)
-	endif(WIN32)
+if ( BUILD_EXAMPLE )
+	set(DISCOVERY_EXAMPLE_SOURCES discovery_example.cpp)
+	set(DISCOVERY_EXAMPLE_LIBS udp-discovery)
 
 	if(APPLE)
 	elseif(UNIX)
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+		set(DISCOVERY_EXAMPLE_LIBS ${DISCOVERY_EXAMPLE_LIBS} rt)
 	endif()
+
+	if(WIN32)
+		set(DISCOVERY_EXAMPLE_LIBS ${DISCOVERY_EXAMPLE_LIBS} Ws2_32)
+	endif(WIN32)
 
 	add_executable(udp-discovery-example ${DISCOVERY_EXAMPLE_SOURCES})
 	target_link_libraries(udp-discovery-example ${DISCOVERY_EXAMPLE_LIBS})
+endif()
+
+if ( BUILD_TOOL )
+	set(DISCOVERY_TOOL_SOURCES discovery_tool.cpp)
+	set(DISCOVERY_TOOL_LIBS udp-discovery)
+
+	if(APPLE)
+	elseif(UNIX)
+		set(DISCOVERY_TOOL_LIBS ${DISCOVERY_TOOL_LIBS} rt)
+	endif()
 
 	add_executable(udp-discovery-tool ${DISCOVERY_TOOL_SOURCES})
 	target_link_libraries(udp-discovery-tool ${DISCOVERY_TOOL_LIBS})

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library uses [CMake](https://cmake.org/) to build static library, examples 
 cd udp-discovery-cpp
 mkdir build
 cd build
-cmake ..
+cmake -DBUILD_EXAMPLE=ON -DBUILD_TOOL=ON ..
 make
 </pre>
 


### PR DESCRIPTION
Require linker dependencies only if executables are built
Fix missing library linking regression introduced in my previous PR

Sorry to not have included this in latest PR, you where much faster then I expected!