### PR TITLE
Multicast support and working func improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ option(BUILD_EXAMPLE "Build example application." OFF)
 option(BUILD_TOOL "Build udp-discovery-tool application." OFF)
 
 set(LIB_SOURCES
-	udp_discovery_peer.cpp
 	udp_discovery_ip_port.cpp
+	udp_discovery_peer.cpp
 	udp_discovery_protocol.cpp)
 set(LIB_HEADERS
-	udp_discovery_peer.hpp
 	udp_discovery_ip_port.hpp
+	udp_discovery_peer.hpp
 	udp_discovery_protocol.hpp)
 
 add_library(udp-discovery STATIC ${LIB_SOURCES} ${LIB_HEADERS})

--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ bool is_same = udpdiscovery::Same(parameters.same_peer_mode(), discovered_peers,
 
 The example program **udp-discovery-example** has the following arguments:
 <pre>
-Usage: ./udp-discovery-example {discover|discoverable|both} [user_data]
+Usage: ./udp-discovery-example {broadcast|multicast|both} {discover|discoverable|both} [user_data]
+
+broadcast - this instance will use broadcasting for being discovered by others
+multicast - this instance will use multicast group (224.0.0.123) for discovery
+both - this instance will use both broadcasting and multicast group (224.0.0.123) for discovery
 
 discover - this instance will have the ability to only discover other instances
 discoverable - this instance will have the ability to only be discovered by other instances

--- a/discovery_example.cpp
+++ b/discovery_example.cpp
@@ -18,8 +18,8 @@ void Usage(int argc, char* argv[]) {
   std::cout << "Usage: " << argv[0] << " {broadcast|multicast|both} {discover|discoverable|both} [user_data]" << std::endl;
   std::cout << std::endl;
   std::cout << "broadcast - this instance will use broadcasting for being discovered by others" << std::endl;
-  std::cout << "multicast - this instance will use multicast group (224.0.1.222) for discovery" << std::endl;
-  std::cout << "both - this instance will use both broadcasting and multicast group (224.0.1.222) for discovery" << std::endl;
+  std::cout << "multicast - this instance will use multicast group (224.0.0.123) for discovery" << std::endl;
+  std::cout << "both - this instance will use both broadcasting and multicast group (224.0.0.123) for discovery" << std::endl;
   std::cout << std::endl;
   std::cout << "discover - this instance will have the ability to only discover other instances" << std::endl;
   std::cout << "discoverable - this instance will have the ability to only be discovered by other instances" << std::endl;

--- a/udp_discovery_peer_parameters.hpp
+++ b/udp_discovery_peer_parameters.hpp
@@ -8,28 +8,23 @@ namespace udpdiscovery {
    public:
     enum SamePeerMode {
       kSamePeerIp,
-      kSamePeerIpAndPort
+      kSamePeerIpAndPort,
     };
 
    public:
     PeerParameters()
-        : port_(0),
-          application_id_(0),
-          receive_timeout_ms_(200),
+        : application_id_(0),
+          can_use_broadcast_(true),
+          can_use_multicast_(false),
+          port_(0),
+          multicast_group_address_(0),
+          receive_timeout_ms_(1000),
           send_timeout_ms_(5000),
           discovered_peer_ttl_ms_(10000),
           can_be_discovered_(false),
           can_discover_(false),
           discover_self_(false),
           same_peer_mode_(kSamePeerIpAndPort) {
-    }
-
-    int port() const {
-      return port_;
-    }
-
-    void set_port(int port) {
-      port_ = port;
     }
 
     uint32_t application_id() const {
@@ -40,31 +35,63 @@ namespace udpdiscovery {
       application_id_ = application_id;
     }
 
-    int receive_timeout_ms() const {
+    bool can_use_broadcast() const {
+      return can_use_broadcast_;
+    }
+
+    void set_can_use_broadcast(bool can_use_broadcast) {
+      can_use_broadcast_ = can_use_broadcast;
+    }
+
+    bool can_use_multicast() const {
+      return can_use_multicast_;
+    }
+
+    void set_can_use_multicast(bool can_use_multicast) {
+      can_use_multicast_ = can_use_multicast;
+    }
+
+    int port() const {
+      return port_;
+    }
+
+    void set_port(int port) {
+      port_ = port;
+    }
+
+    unsigned int multicast_group_address() const {
+      return multicast_group_address_;
+    }
+
+    void set_multicast_group_address(unsigned int group_address) {
+      multicast_group_address_ = group_address;
+    }
+
+    long receive_timeout_ms() const {
       return receive_timeout_ms_;
     }
 
-    void set_receive_timeout_ms(int receive_timeout_ms) {
+    void set_receive_timeout_ms(long receive_timeout_ms) {
       if (receive_timeout_ms < 0)
         return;
       receive_timeout_ms_ = receive_timeout_ms;
     }
 
-    int send_timeout_ms() const {
+    long send_timeout_ms() const {
       return send_timeout_ms_;
     }
 
-    void set_send_timeout_ms(int send_timeout_ms) {
+    void set_send_timeout_ms(long send_timeout_ms) {
       if (send_timeout_ms < 0)
         return;
       send_timeout_ms_ = send_timeout_ms;
     }
 
-    int discovered_peer_ttl_ms() const {
+    long discovered_peer_ttl_ms() const {
       return discovered_peer_ttl_ms_;
     }
 
-    void set_discovered_peer_ttl_ms(int discovered_peer_ttl_ms) {
+    void set_discovered_peer_ttl_ms(long discovered_peer_ttl_ms) {
       if (discovered_peer_ttl_ms < 0)
         return;
       discovered_peer_ttl_ms_ = discovered_peer_ttl_ms;
@@ -103,11 +130,14 @@ namespace udpdiscovery {
     }
 
    private:
-    int port_;
     uint32_t application_id_;
-    int receive_timeout_ms_;
-    int send_timeout_ms_;
-    int discovered_peer_ttl_ms_;
+    bool can_use_broadcast_;
+    bool can_use_multicast_;
+    int port_;
+    unsigned int multicast_group_address_;
+    long receive_timeout_ms_;
+    long send_timeout_ms_;
+    long discovered_peer_ttl_ms_;
     bool can_be_discovered_;
     bool can_discover_;
     bool discover_self_;


### PR DESCRIPTION
Adds support for multicast discovery. Multicast discovery is off by default (the regular broadcasting is the default mode).

Improves peer working function. This function now correctly waits for the next event: receiving, sending, checking old discovered peers.